### PR TITLE
Bugfixing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 2025-03-05: First official release (0.75)
 2025-03-21: Bump to v0.80 - Add support for external labels, such as BIOS calls. Improved code detection methods.
 2025-06-13: Bump to v0.85 - Add the ability to define user-defined labels to the labels file. Increased error handling, more informational messages.
+2025-06-18: Bump to v0.87 - Corrected issues with string detection where strings weren't being properly decoded.

--- a/z80-disassembler.py
+++ b/z80-disassembler.py
@@ -90,7 +90,7 @@ str_locations = {}
 str_sizes = {}
 style = "asm"
 hexstyle = "0x"
-myversion = "0.85"
+myversion = "0.87"
 
 
 #--- Debugging functions ---


### PR DESCRIPTION
Mostly to solve issue #30 

I redid the string matching, but it won't find strings <3 characters long. Less than that is too noisy, but the Amstrad string+0x80 method won't be detected,

It does solve the issue with the strings being randomly assigned. 